### PR TITLE
CLOUD-1772: Update language to use Control Room

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Upload Robot to Robocorp Cloud
+      - name: Upload Robot to Control Room
         uses: ./
         with:
           workspace-key: ${{ secrets.ROBOCORP_WORKSPACE_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# GitHub action to update a robot in Robocorp Cloud
+# GitHub action to update a robot in Robocorp Control Room
 
-This GitHub Actions uploads a robot to Robocorp Cloud. It updates a robot existing in Robocorp Cloud,
+This GitHub Actions uploads a robot to Robocorp Control Room. It updates a robot existing in Control Room,
 identified by `robot-id` option.
 
 ## Usage
 
 ### Example Workflow file
 
-An example workflow file to update robot in Robocorp Cloud:
+An example workflow file to update robot in Control Room:
 
 ```yaml
 jobs:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v2
-      - name: Upload robot to Robocorp Cloud
+      - name: Upload robot to Control Room
         uses: robocorp/action-upload-robot@v1
         with:
           workspace-key: ${{ secrets.ROBOCORP_WORKSPACE_KEY }}
@@ -31,6 +31,6 @@ jobs:
 | -------------- | ------- | ---------------------------- | ------------------------------------------ |
 | workspace-id   | string  |                              | The workspace ID                           |
 | workspace-key  | string  |                              | Workspace API key in target workspace      |
-| robot-id       | string  |                              | ID of the robot in Robocorp Cloud          |
-| api-endpoint   | string  | https://api.eu1.robocloud.eu | Robocorp Cloud API URL                     |
+| robot-id       | string  |                              | ID of the robot in Control Room            |
+| api-endpoint   | string  | https://api.eu1.robocloud.eu | Control Room API URL                       |
 | robot-dir      | string  | ./                           | Directory which to pack and upload         |

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Upload robot to Robocorp Cloud'
-description: 'Upload robot to Robocorp Cloud'
+name: 'Upload robot to Robocorp Control Room'
+description: 'Upload robot to Robocorp Control Room'
 author: 'Robocorp'
 branding:
   color: 'purple'
@@ -16,7 +16,7 @@ inputs:
     description: 'ID of robot to update'
     required: true
   api-endpoint:
-    description: 'Robocorp Cloud API URL'
+    description: 'Control Room API URL'
     default: 'https://api.eu1.robocloud.eu'
     required: false
   robot-dir:


### PR DESCRIPTION
- Update language to use the new brandname `Control Room` instead of `Robocorp Cloud`